### PR TITLE
feat: scrape LinkedIn message histories and store in DynamoDB

### DIFF
--- a/backend/lambdas/edge-processing/lambda_function.py
+++ b/backend/lambdas/edge-processing/lambda_function.py
@@ -228,6 +228,12 @@ def lambda_handler(event, context):
                 },
                 event,
             )
+        if op == 'update_messages':
+            if not pid:
+                return _resp(400, {'error': 'profileId required'}, event)
+            msgs = updates.get('messages', [])
+            r = svc.update_messages(user_id, pid, msgs)
+            return _resp(200, {'result': r}, event)
         if op == 'get_messages':
             if not pid:
                 return _resp(400, {'error': 'profileId required'}, event)

--- a/backend/lambdas/edge-processing/services/edge_service.py
+++ b/backend/lambdas/edge-processing/services/edge_service.py
@@ -318,18 +318,19 @@ class EdgeService(BaseService):
                 message='Failed to get messages', service='DynamoDB', original_error=str(e)
             ) from e
 
-    def check_exists(self, user_id: str, profile_id_b64: str) -> dict[str, Any]:
+    def check_exists(self, user_id: str, profile_id: str) -> dict[str, Any]:
         """
         Check if an edge exists between user and profile.
 
         Args:
             user_id: User ID
-            profile_id_b64: Base64-encoded profile ID
+            profile_id: LinkedIn profile identifier (plain, not base64)
 
         Returns:
             dict with exists flag and edge data if exists
         """
         try:
+            profile_id_b64 = base64.urlsafe_b64encode(profile_id.encode()).decode()
             response = self.table.get_item(Key={'PK': f'USER#{user_id}', 'SK': f'PROFILE#{profile_id_b64}'})
 
             edge_exists = 'Item' in response

--- a/backend/lambdas/edge-processing/services/edge_service.py
+++ b/backend/lambdas/edge-processing/services/edge_service.py
@@ -213,6 +213,40 @@ class EdgeService(BaseService):
                 message='Failed to add message', service='DynamoDB', original_error=str(e)
             ) from e
 
+    def update_messages(self, user_id: str, profile_id: str, messages: list) -> dict[str, Any]:
+        """
+        Replace the full messages list on an edge (used after scraping a conversation).
+
+        Args:
+            user_id: User ID from Cognito
+            profile_id: LinkedIn profile identifier (plain, not base64)
+            messages: List of message dicts {content, timestamp, type}
+
+        Returns:
+            dict with success status and message count
+        """
+        try:
+            profile_id_b64 = base64.urlsafe_b64encode(profile_id.encode()).decode()
+            current_time = datetime.now(UTC).isoformat()
+            trimmed = messages[-MAX_MESSAGES_PER_EDGE:] if messages else []
+
+            self.table.update_item(
+                Key={'PK': f'USER#{user_id}', 'SK': f'PROFILE#{profile_id_b64}'},
+                UpdateExpression='SET messages = :msgs, updatedAt = :updated',
+                ExpressionAttributeValues={
+                    ':msgs': trimmed,
+                    ':updated': current_time,
+                },
+            )
+
+            return {'success': True, 'messageCount': len(trimmed), 'profileId': profile_id_b64}
+
+        except ClientError as e:
+            logger.error(f'DynamoDB error in update_messages: {e}')
+            raise ExternalServiceError(
+                message='Failed to update messages', service='DynamoDB', original_error=str(e)
+            ) from e
+
     def get_connections_by_status(self, user_id: str, status: str | None = None) -> dict[str, Any]:
         """
         Get user connections, optionally filtered by status.

--- a/frontend/src/features/messages/hooks/useMessageHistory.test.ts
+++ b/frontend/src/features/messages/hooks/useMessageHistory.test.ts
@@ -1,7 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useMessageHistory } from './useMessageHistory';
 import type { Message } from '@/types';
+
+// Mock cognito service to prevent UserPool init error
+vi.mock('@/features/auth/services/cognitoService', () => ({
+  default: {
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    getCurrentUser: vi.fn(),
+    getToken: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('@/features/auth', () => ({
+  useAuth: () => ({ user: null, isAuthenticated: false, signIn: vi.fn(), signOut: vi.fn() }),
+  CognitoAuthService: { getToken: vi.fn().mockResolvedValue(null) },
+}));
+
+import { useMessageHistory } from './useMessageHistory';
 
 describe('useMessageHistory', () => {
   it('starts with empty messages', () => {

--- a/frontend/src/features/messages/hooks/useMessageHistory.ts
+++ b/frontend/src/features/messages/hooks/useMessageHistory.ts
@@ -17,7 +17,11 @@ export function useMessageHistory() {
     setError(null);
     try {
       const fetched = await lambdaApiService.getMessageHistory(connectionId);
-      setMessages(fetched);
+      if (Array.isArray(fetched)) {
+        setMessages(fetched);
+      } else {
+        setMessages([]);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load messages');
       setMessages([]);

--- a/frontend/src/features/messages/hooks/useMessageHistory.ts
+++ b/frontend/src/features/messages/hooks/useMessageHistory.ts
@@ -1,13 +1,14 @@
 import { useState, useCallback } from 'react';
 import type { Message } from '@/types';
+import { lambdaApiService } from '@/shared/services';
 
 export function useMessageHistory() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchHistory = useCallback(async (_connectionId: string | null) => {
-    if (!_connectionId) {
+  const fetchHistory = useCallback(async (connectionId: string | null) => {
+    if (!connectionId) {
       setMessages([]);
       return;
     }
@@ -15,9 +16,8 @@ export function useMessageHistory() {
     setIsLoading(true);
     setError(null);
     try {
-      // Message history fetching - currently returns empty (matches original behavior)
-      // Real implementation would fetch from API
-      setMessages([]);
+      const fetched = await lambdaApiService.getMessageHistory(connectionId);
+      setMessages(fetched);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load messages');
       setMessages([]);

--- a/puppeteer/src/domains/messaging/services/linkedinMessageScraperService.js
+++ b/puppeteer/src/domains/messaging/services/linkedinMessageScraperService.js
@@ -1,0 +1,451 @@
+/**
+ * LinkedIn Message Scraper Service - Reads/extracts messages from LinkedIn's messaging UI.
+ *
+ * Follows the same patterns as linkedinService.ts (multi-selector fallbacks,
+ * intelligent scrolling, random delays).
+ */
+
+import { logger } from '#utils/logger.js';
+
+const MAX_MESSAGES_PER_EDGE = 100;
+
+/**
+ * Random delay helper (inline to avoid import complexity).
+ * @param {number} minMs
+ * @param {number} maxMs
+ */
+function randomDelay(minMs, maxMs) {
+  const span = Math.max(0, maxMs - minMs);
+  const delayMs = minMs + Math.floor(Math.random() * (span + 1));
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+/**
+ * Service dedicated to reading/extracting messages from LinkedIn's messaging UI.
+ */
+export class LinkedInMessageScraperService {
+  /**
+   * @param {Object} options
+   * @param {Object} options.sessionManager - Browser session manager for page access
+   */
+  constructor(options = {}) {
+    this.sessionManager = options.sessionManager;
+    if (!this.sessionManager) {
+      throw new Error('LinkedInMessageScraperService requires sessionManager');
+    }
+  }
+
+  /**
+   * Main entry point for profile init — scrape all conversations matching known connection IDs.
+   * @param {string[]} connectionProfileIds - Known connection profile IDs
+   * @param {Object} [options]
+   * @param {number} [options.maxConversations=50] - Max conversations to process
+   * @param {number} [options.maxScrolls=20] - Max sidebar scrolls
+   * @returns {Promise<Map<string, Array>>} Map of profileId -> messages
+   */
+  async scrapeAllConversations(connectionProfileIds, options = {}) {
+    const maxConversations = options.maxConversations || 50;
+    const maxScrolls = options.maxScrolls || 20;
+    const results = new Map();
+
+    if (!connectionProfileIds || connectionProfileIds.length === 0) {
+      logger.info('No connection profile IDs provided, skipping message scraping');
+      return results;
+    }
+
+    const connectionSet = new Set(connectionProfileIds);
+
+    try {
+      await this._navigateToMessaging();
+      await this._delay(1500, 2500);
+
+      await this._scrollConversationList(maxScrolls);
+
+      const conversationEntries = await this._extractConversationEntries();
+      logger.info(`Found ${conversationEntries.length} conversations in sidebar`);
+
+      // Filter to only conversations matching known connections
+      const matchingEntries = conversationEntries.filter((entry) =>
+        connectionSet.has(entry.profileId)
+      );
+      logger.info(
+        `${matchingEntries.length} conversations match known connections (of ${connectionProfileIds.length} total)`
+      );
+
+      // Process up to maxConversations
+      const toProcess = matchingEntries.slice(0, maxConversations);
+
+      for (const entry of toProcess) {
+        try {
+          await this._clickConversation(entry);
+          await this._delay(1000, 2000);
+
+          await this._scrollThreadUp(10);
+
+          const messages = await this._extractMessages();
+          if (messages.length > 0) {
+            results.set(entry.profileId, messages.slice(-MAX_MESSAGES_PER_EDGE));
+            logger.info(`Scraped ${messages.length} messages for ${entry.profileId}`);
+          }
+
+          await this._delay(1000, 2000);
+        } catch (error) {
+          logger.warn(`Failed to scrape conversation for ${entry.profileId}: ${error.message}`);
+          // Continue with remaining conversations
+        }
+      }
+
+      logger.info(`Message scraping complete: ${results.size} conversations scraped`);
+      return results;
+    } catch (error) {
+      logger.error(`Message scraping failed: ${error.message}`);
+      return results; // Return partial results
+    }
+  }
+
+  /**
+   * Extract messages from a single open/navigated conversation thread.
+   * @param {string} profileId - Profile ID to scrape conversation for
+   * @returns {Promise<Array>} Array of message objects
+   */
+  async scrapeConversationThread(profileId) {
+    try {
+      const page = await this._getPage();
+
+      // Check if we're already on a messaging thread, otherwise navigate
+      const currentUrl = page.url();
+      if (!currentUrl.includes('/messaging/')) {
+        await this._navigateToMessaging();
+        await this._delay(1000, 1500);
+      }
+
+      // Try to find and click the conversation for this profile in the sidebar
+      const conversationEntries = await this._extractConversationEntries();
+      const targetEntry = conversationEntries.find((e) => e.profileId === profileId);
+
+      if (targetEntry) {
+        await this._clickConversation(targetEntry);
+        await this._delay(1000, 1500);
+      }
+
+      await this._scrollThreadUp(10);
+      const messages = await this._extractMessages();
+
+      logger.info(`Scraped ${messages.length} messages from thread for ${profileId}`);
+      return messages.slice(-MAX_MESSAGES_PER_EDGE);
+    } catch (error) {
+      logger.warn(`Failed to scrape conversation thread for ${profileId}: ${error.message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Navigate to LinkedIn's /messaging/ page.
+   */
+  async _navigateToMessaging() {
+    const page = await this._getPage();
+
+    await page.goto('https://www.linkedin.com/messaging/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30000,
+    });
+
+    // Wait for conversation list to appear
+    const listSelectors = [
+      '.msg-conversations-container__conversations-list',
+      '[data-view-name*="conversation"]',
+      '.msg-conversation-listitem',
+      'ul.msg-conversations-container__conversations-list',
+    ];
+
+    for (const selector of listSelectors) {
+      try {
+        await page.waitForSelector(selector, { timeout: 8000 });
+        return;
+      } catch {
+        // try next
+      }
+    }
+
+    logger.warn('Could not confirm messaging page loaded via selectors');
+  }
+
+  /**
+   * Scroll the conversation sidebar to load all conversations.
+   * Uses intelligent stop — halts when conversation count stabilizes.
+   * @param {number} maxScrolls
+   */
+  async _scrollConversationList(maxScrolls = 20) {
+    const page = await this._getPage();
+    let previousCount = 0;
+    let stableRounds = 0;
+
+    for (let i = 0; i < maxScrolls; i++) {
+      const currentCount = await page.evaluate(() => {
+        const listSelectors = [
+          '.msg-conversations-container__conversations-list li',
+          '.msg-conversation-listitem',
+          'li[class*="msg-conversation"]',
+        ];
+        for (const sel of listSelectors) {
+          const items = document.querySelectorAll(sel);
+          if (items.length > 0) return items.length;
+        }
+        return 0;
+      });
+
+      if (currentCount === previousCount) {
+        stableRounds++;
+        if (stableRounds >= 3) {
+          logger.debug(
+            `Conversation list stabilized at ${currentCount} items after ${i + 1} scrolls`
+          );
+          break;
+        }
+      } else {
+        stableRounds = 0;
+      }
+      previousCount = currentCount;
+
+      // Scroll the conversation list container
+      await page.evaluate(() => {
+        const containerSelectors = [
+          '.msg-conversations-container__conversations-list',
+          '.msg-conversations-container',
+          '[class*="msg-conversations"]',
+        ];
+        for (const sel of containerSelectors) {
+          const container = document.querySelector(sel);
+          if (container) {
+            container.scrollTop = container.scrollHeight;
+            return;
+          }
+        }
+      });
+
+      await this._delay(800, 1500);
+    }
+  }
+
+  /**
+   * Extract conversation entries from the sidebar.
+   * @returns {Promise<Array<{profileId: string, index: number}>>}
+   */
+  async _extractConversationEntries() {
+    const page = await this._getPage();
+
+    return await page.evaluate(() => {
+      const entries = [];
+      const itemSelectors = [
+        '.msg-conversation-listitem',
+        'li[class*="msg-conversation"]',
+        '[data-view-name*="conversation"]',
+      ];
+
+      let items = [];
+      for (const sel of itemSelectors) {
+        items = Array.from(document.querySelectorAll(sel));
+        if (items.length > 0) break;
+      }
+
+      items.forEach((item, index) => {
+        // Find profile link within conversation item
+        const profileLink = item.querySelector('a[href*="/in/"]');
+        if (profileLink) {
+          const href = profileLink.getAttribute('href') || '';
+          const match = href.match(/\/in\/([^/?\s]+)/);
+          if (match && match[1]) {
+            entries.push({
+              profileId: match[1].replace(/\/$/, ''),
+              index,
+            });
+          }
+        }
+      });
+
+      return entries;
+    });
+  }
+
+  /**
+   * Click a conversation in the sidebar and wait for thread to load.
+   * @param {{profileId: string, index: number}} entry
+   */
+  async _clickConversation(entry) {
+    const page = await this._getPage();
+
+    await page.evaluate((idx) => {
+      const itemSelectors = [
+        '.msg-conversation-listitem',
+        'li[class*="msg-conversation"]',
+        '[data-view-name*="conversation"]',
+      ];
+
+      for (const sel of itemSelectors) {
+        const items = document.querySelectorAll(sel);
+        if (items.length > idx) {
+          // Click the item or its first clickable child
+          const clickable = items[idx].querySelector('a') || items[idx];
+          clickable.click();
+          return;
+        }
+      }
+    }, entry.index);
+
+    // Wait for message thread to load
+    const threadSelectors = [
+      '.msg-s-message-list',
+      '[class*="msg-s-message-list"]',
+      '[role="list"]',
+    ];
+
+    for (const selector of threadSelectors) {
+      try {
+        await page.waitForSelector(selector, { timeout: 5000 });
+        return;
+      } catch {
+        // try next
+      }
+    }
+  }
+
+  /**
+   * Scroll up in the message thread to load older messages.
+   * @param {number} maxScrolls
+   */
+  async _scrollThreadUp(maxScrolls = 10) {
+    const page = await this._getPage();
+    let previousCount = 0;
+    let stableRounds = 0;
+
+    for (let i = 0; i < maxScrolls; i++) {
+      const currentCount = await page.evaluate(() => {
+        const msgSelectors = [
+          '.msg-s-event-listitem',
+          '[data-view-name*="message"]',
+          '.msg-s-message-list__event',
+        ];
+        for (const sel of msgSelectors) {
+          const items = document.querySelectorAll(sel);
+          if (items.length > 0) return items.length;
+        }
+        return 0;
+      });
+
+      if (currentCount === previousCount) {
+        stableRounds++;
+        if (stableRounds >= 3) break;
+      } else {
+        stableRounds = 0;
+      }
+      previousCount = currentCount;
+
+      // Scroll the thread container up
+      await page.evaluate(() => {
+        const containerSelectors = ['.msg-s-message-list', '[class*="msg-s-message-list"]'];
+        for (const sel of containerSelectors) {
+          const container = document.querySelector(sel);
+          if (container) {
+            container.scrollTop = 0;
+            return;
+          }
+        }
+      });
+
+      await this._delay(800, 1200);
+    }
+  }
+
+  /**
+   * Extract messages from the currently visible thread.
+   * @returns {Promise<Array<{id: string, content: string, timestamp: string, sender: string}>>}
+   */
+  async _extractMessages() {
+    const page = await this._getPage();
+
+    return await page.evaluate(() => {
+      const messages = [];
+      const itemSelectors = [
+        '.msg-s-event-listitem',
+        '[data-view-name*="message"]',
+        '.msg-s-message-list__event',
+      ];
+
+      let items = [];
+      for (const sel of itemSelectors) {
+        items = Array.from(document.querySelectorAll(sel));
+        if (items.length > 0) break;
+      }
+
+      items.forEach((item, index) => {
+        // Extract content
+        const contentSelectors = [
+          '.msg-s-event-listitem__body',
+          'p[dir="ltr"]',
+          '.msg-s-event__content',
+        ];
+        let content = '';
+        for (const sel of contentSelectors) {
+          const el = item.querySelector(sel);
+          if (el && el.textContent.trim()) {
+            content = el.textContent.trim();
+            break;
+          }
+        }
+
+        if (!content) return; // Skip non-message events (e.g., connection requests)
+
+        // Extract timestamp
+        let timestamp = new Date().toISOString();
+        const timeEl =
+          item.querySelector('time[datetime]') ||
+          item.querySelector('.msg-s-message-list__time-heading');
+        if (timeEl) {
+          const dt = timeEl.getAttribute('datetime');
+          if (dt) {
+            timestamp = dt;
+          } else if (timeEl.textContent) {
+            timestamp = timeEl.textContent.trim();
+          }
+        }
+
+        // Determine sender: presence of "other" class indicates inbound
+        const isInbound =
+          item.classList.contains('msg-s-event-listitem--other') ||
+          item.querySelector('.msg-s-event-listitem--other') !== null ||
+          item.closest('.msg-s-event-listitem--other') !== null;
+
+        messages.push({
+          id: `msg-${Date.now()}-${index}`,
+          content,
+          timestamp,
+          sender: isInbound ? 'inbound' : 'outbound',
+        });
+      });
+
+      return messages;
+    });
+  }
+
+  /**
+   * Rate-limiting delay between actions. Extracted as a method for testability.
+   * @param {number} minMs
+   * @param {number} maxMs
+   */
+  async _delay(minMs, maxMs) {
+    await randomDelay(minMs, maxMs);
+  }
+
+  /**
+   * Get the Puppeteer page from the session manager.
+   * @returns {Promise<Page>}
+   */
+  async _getPage() {
+    const session = await this.sessionManager.getInstance({
+      reinitializeIfUnhealthy: false,
+    });
+    return session.getPage();
+  }
+}
+
+export default LinkedInMessageScraperService;

--- a/puppeteer/src/domains/messaging/services/linkedinMessageScraperService.test.js
+++ b/puppeteer/src/domains/messaging/services/linkedinMessageScraperService.test.js
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('#utils/logger.js', () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { LinkedInMessageScraperService } from './linkedinMessageScraperService.js';
+
+function createMockSessionManager() {
+  return {
+    getInstance: vi.fn().mockResolvedValue({
+      getPage: () => ({
+        url: vi.fn(() => 'https://www.linkedin.com/messaging/'),
+        goto: vi.fn().mockResolvedValue(null),
+        waitForSelector: vi.fn().mockResolvedValue({}),
+        evaluate: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  };
+}
+
+describe('LinkedInMessageScraperService', () => {
+  let service;
+  let mockSessionManager;
+
+  beforeEach(() => {
+    mockSessionManager = createMockSessionManager();
+    service = new LinkedInMessageScraperService({ sessionManager: mockSessionManager });
+    // Stub delays to avoid timeouts in tests
+    service._delay = vi.fn().mockResolvedValue();
+  });
+
+  describe('constructor', () => {
+    it('requires sessionManager', () => {
+      expect(() => new LinkedInMessageScraperService()).toThrow(
+        'LinkedInMessageScraperService requires sessionManager'
+      );
+    });
+
+    it('accepts sessionManager', () => {
+      const svc = new LinkedInMessageScraperService({ sessionManager: mockSessionManager });
+      expect(svc.sessionManager).toBe(mockSessionManager);
+    });
+  });
+
+  describe('scrapeAllConversations', () => {
+    it('returns empty Map when no connection IDs provided', async () => {
+      const result = await service.scrapeAllConversations([]);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('returns empty Map when connectionProfileIds is null', async () => {
+      const result = await service.scrapeAllConversations(null);
+      expect(result).toBeInstanceOf(Map);
+      expect(result.size).toBe(0);
+    });
+
+    it('navigates to /messaging/ page', async () => {
+      // Stub internal methods to isolate navigation test
+      service._navigateToMessaging = vi.fn().mockResolvedValue();
+      service._scrollConversationList = vi.fn().mockResolvedValue();
+      service._extractConversationEntries = vi.fn().mockResolvedValue([]);
+
+      await service.scrapeAllConversations(['john-doe']);
+
+      expect(service._navigateToMessaging).toHaveBeenCalled();
+    });
+
+    it('filters conversations to matching connection IDs', async () => {
+      service._navigateToMessaging = vi.fn().mockResolvedValue();
+      service._scrollConversationList = vi.fn().mockResolvedValue();
+      service._extractConversationEntries = vi.fn().mockResolvedValue([
+        { profileId: 'john-doe', index: 0 },
+        { profileId: 'jane-smith', index: 1 },
+        { profileId: 'bob-wilson', index: 2 },
+      ]);
+      service._clickConversation = vi.fn().mockResolvedValue();
+      service._scrollThreadUp = vi.fn().mockResolvedValue();
+      service._extractMessages = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 'msg-1', content: 'Hello', timestamp: '2024-01-01T00:00:00', sender: 'outbound' },
+        ]);
+
+      const result = await service.scrapeAllConversations(['john-doe', 'bob-wilson']);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.has('john-doe')).toBe(true);
+      expect(result.has('bob-wilson')).toBe(true);
+      expect(result.has('jane-smith')).toBe(false);
+    });
+
+    it('returns partial results when individual conversations fail', async () => {
+      service._navigateToMessaging = vi.fn().mockResolvedValue();
+      service._scrollConversationList = vi.fn().mockResolvedValue();
+      service._extractConversationEntries = vi.fn().mockResolvedValue([
+        { profileId: 'john-doe', index: 0 },
+        { profileId: 'jane-smith', index: 1 },
+      ]);
+      service._clickConversation = vi.fn().mockResolvedValue();
+      service._scrollThreadUp = vi.fn().mockResolvedValue();
+
+      let callCount = 0;
+      service._extractMessages = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve([
+            { id: 'msg-1', content: 'Hello', timestamp: '2024-01-01', sender: 'outbound' },
+          ]);
+        }
+        return Promise.reject(new Error('Extraction failed'));
+      });
+
+      const result = await service.scrapeAllConversations(['john-doe', 'jane-smith']);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.has('john-doe')).toBe(true);
+      expect(result.get('john-doe')).toHaveLength(1);
+    });
+
+    it('respects maxConversations option', async () => {
+      service._navigateToMessaging = vi.fn().mockResolvedValue();
+      service._scrollConversationList = vi.fn().mockResolvedValue();
+      service._extractConversationEntries = vi.fn().mockResolvedValue([
+        { profileId: 'user-1', index: 0 },
+        { profileId: 'user-2', index: 1 },
+        { profileId: 'user-3', index: 2 },
+      ]);
+      service._clickConversation = vi.fn().mockResolvedValue();
+      service._scrollThreadUp = vi.fn().mockResolvedValue();
+      service._extractMessages = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 'msg-1', content: 'Hi', timestamp: '2024-01-01', sender: 'outbound' },
+        ]);
+
+      const result = await service.scrapeAllConversations(['user-1', 'user-2', 'user-3'], {
+        maxConversations: 2,
+      });
+
+      expect(service._clickConversation).toHaveBeenCalledTimes(2);
+      expect(result.size).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('scrapeConversationThread', () => {
+    it('returns messages from open thread', async () => {
+      const messages = [
+        { id: 'msg-1', content: 'Hello', timestamp: '2024-01-01T00:00:00', sender: 'outbound' },
+        { id: 'msg-2', content: 'Hi there', timestamp: '2024-01-01T00:01:00', sender: 'inbound' },
+      ];
+
+      service._extractConversationEntries = vi
+        .fn()
+        .mockResolvedValue([{ profileId: 'john-doe', index: 0 }]);
+      service._clickConversation = vi.fn().mockResolvedValue();
+      service._scrollThreadUp = vi.fn().mockResolvedValue();
+      service._extractMessages = vi.fn().mockResolvedValue(messages);
+
+      const result = await service.scrapeConversationThread('john-doe');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].content).toBe('Hello');
+      expect(result[1].sender).toBe('inbound');
+    });
+
+    it('returns empty array on failure', async () => {
+      service._extractConversationEntries = vi.fn().mockRejectedValue(new Error('Page crashed'));
+
+      const result = await service.scrapeConversationThread('john-doe');
+
+      expect(result).toEqual([]);
+    });
+
+    it('navigates to messaging if not already there', async () => {
+      const mockPage = {
+        url: vi.fn(() => 'https://www.linkedin.com/in/john-doe/'),
+        goto: vi.fn().mockResolvedValue(null),
+        waitForSelector: vi.fn().mockResolvedValue({}),
+        evaluate: vi.fn().mockResolvedValue([]),
+      };
+      mockSessionManager.getInstance.mockResolvedValue({ getPage: () => mockPage });
+
+      service._navigateToMessaging = vi.fn().mockResolvedValue();
+      service._extractConversationEntries = vi.fn().mockResolvedValue([]);
+      service._scrollThreadUp = vi.fn().mockResolvedValue();
+      service._extractMessages = vi.fn().mockResolvedValue([]);
+
+      await service.scrapeConversationThread('john-doe');
+
+      expect(service._navigateToMessaging).toHaveBeenCalled();
+    });
+  });
+
+  describe('message format', () => {
+    it('returns messages with required fields', async () => {
+      const messages = [
+        {
+          id: 'msg-123-0',
+          content: 'Test message',
+          timestamp: '2024-01-15T10:30:00.000Z',
+          sender: 'outbound',
+        },
+      ];
+
+      service._extractConversationEntries = vi
+        .fn()
+        .mockResolvedValue([{ profileId: 'john-doe', index: 0 }]);
+      service._clickConversation = vi.fn().mockResolvedValue();
+      service._scrollThreadUp = vi.fn().mockResolvedValue();
+      service._extractMessages = vi.fn().mockResolvedValue(messages);
+
+      const result = await service.scrapeConversationThread('john-doe');
+
+      expect(result[0]).toHaveProperty('id');
+      expect(result[0]).toHaveProperty('content');
+      expect(result[0]).toHaveProperty('timestamp');
+      expect(result[0]).toHaveProperty('sender');
+      expect(['outbound', 'inbound']).toContain(result[0].sender);
+    });
+  });
+});

--- a/puppeteer/src/domains/profile/services/profileInitService.ts
+++ b/puppeteer/src/domains/profile/services/profileInitService.ts
@@ -10,9 +10,7 @@ import path from 'path';
 import type { PuppeteerService } from '../../automation/services/puppeteerService.js';
 import type { LinkedInService, ConnectionType } from '../../linkedin/services/linkedinService.js';
 import type { Page } from 'puppeteer';
-// @ts-expect-error - JS module without type declarations
 import { LinkedInMessageScraperService } from '../../messaging/services/linkedinMessageScraperService.js';
-// @ts-expect-error - JS module without type declarations
 import { BrowserSessionManager } from '../../session/services/browserSessionManager.js';
 
 /**

--- a/puppeteer/src/domains/profile/services/profileInitService.ts
+++ b/puppeteer/src/domains/profile/services/profileInitService.ts
@@ -10,6 +10,10 @@ import path from 'path';
 import type { PuppeteerService } from '../../automation/services/puppeteerService.js';
 import type { LinkedInService, ConnectionType } from '../../linkedin/services/linkedinService.js';
 import type { Page } from 'puppeteer';
+// @ts-expect-error - JS module without type declarations
+import { LinkedInMessageScraperService } from '../../messaging/services/linkedinMessageScraperService.js';
+// @ts-expect-error - JS module without type declarations
+import { BrowserSessionManager } from '../../session/services/browserSessionManager.js';
 
 /**
  * Profile initialization state
@@ -192,7 +196,12 @@ interface ErrorDetails {
 interface DynamoDBService {
   setAuthToken(token: string): void;
   checkEdgeExists(profileId: string): Promise<boolean>;
-  upsertEdgeStatus(profileId: string, status: string): Promise<unknown>;
+  upsertEdgeStatus(
+    profileId: string,
+    status: string,
+    extraUpdates?: Record<string, unknown>
+  ): Promise<unknown>;
+  updateMessages(profileId: string, messages: unknown[]): Promise<unknown>;
   getProfileDetails(profileId: string): Promise<unknown>;
   markBadContact(profileId: string): Promise<void>;
   createProfileMetadata?(profileId: string, metadata: Record<string, string>): Promise<unknown>;
@@ -224,6 +233,7 @@ export class ProfileInitService {
   private linkedInService: LinkedInService;
   private linkedInContactService: LinkedInContactService;
   private dynamoDBService: DynamoDBService;
+  private messageScraperService: InstanceType<typeof LinkedInMessageScraperService>;
   private batchSize: number;
 
   constructor(
@@ -236,6 +246,9 @@ export class ProfileInitService {
     this.linkedInService = linkedInService;
     this.linkedInContactService = linkedInContactService;
     this.dynamoDBService = dynamoDBService;
+    this.messageScraperService = new LinkedInMessageScraperService({
+      sessionManager: BrowserSessionManager,
+    });
     this.batchSize = 100;
   }
 
@@ -425,6 +438,9 @@ export class ProfileInitService {
         }
       }
 
+      // Phase 2: Scrape message histories and update edges
+      await this._scrapeAndStoreMessages(masterIndexFile);
+
       // Update final progress summary
       results.progressSummary = ProfileInitStateManager.getProgressSummary(state);
 
@@ -439,6 +455,63 @@ export class ProfileInitService {
     } catch (error) {
       logger.error('Connection list processing failed:', error);
       throw error;
+    }
+  }
+
+  /**
+   * Scrape LinkedIn message histories and store them on edges.
+   * Runs after edge creation so failures don't block profile init.
+   */
+  private async _scrapeAndStoreMessages(masterIndexFile: string): Promise<void> {
+    try {
+      logger.info('Starting message history scraping phase');
+
+      // Collect all connection IDs from batch files in the master index
+      const masterIndex = await this._loadMasterIndex(masterIndexFile);
+      const allConnectionIds: string[] = [];
+
+      for (const connectionType of ['ally', 'outgoing', 'incoming'] as const) {
+        const links = await this._loadExistingLinksFromFiles(connectionType, masterIndex);
+        // Convert URLs to profile IDs if needed
+        for (const link of links) {
+          const match = link.match(/\/in\/([^/?\s]+)/);
+          const profileId = match ? match[1].replace(/\/$/, '') : link;
+          if (profileId && profileId !== 'undefined') {
+            allConnectionIds.push(profileId);
+          }
+        }
+      }
+
+      if (allConnectionIds.length === 0) {
+        logger.info('No connection IDs found for message scraping');
+        return;
+      }
+
+      logger.info(`Scraping message histories for ${allConnectionIds.length} connections`);
+
+      const scrapedMessages =
+        await this.messageScraperService.scrapeAllConversations(allConnectionIds);
+
+      if (scrapedMessages.size === 0) {
+        logger.info('No message histories scraped');
+        return;
+      }
+
+      // Store scraped messages on edges
+      let stored = 0;
+      for (const [profileId, messages] of scrapedMessages) {
+        try {
+          await this.dynamoDBService.updateMessages(profileId, messages);
+          stored++;
+        } catch (error) {
+          logger.warn(`Failed to store messages for ${profileId}: ${(error as Error).message}`);
+        }
+      }
+
+      logger.info(`Message scraping phase complete: ${stored}/${scrapedMessages.size} stored`);
+    } catch (error) {
+      // Message scraping failure should NOT block profile init
+      logger.warn(`Message scraping phase failed (non-blocking): ${(error as Error).message}`);
     }
   }
 

--- a/puppeteer/src/domains/profile/services/profileInitService.ts
+++ b/puppeteer/src/domains/profile/services/profileInitService.ts
@@ -1172,6 +1172,7 @@ export class ProfileInitService {
           const fileData = JSON.parse(fileContent) as {
             links?: string[];
             invitations?: Array<{ originalUrl?: string; profileId?: string }>;
+            connections?: string[] | Array<{ url?: string; id?: string; profileId?: string }>;
           };
 
           if (fileData.links) {
@@ -1180,6 +1181,14 @@ export class ProfileInitService {
             allLinks.push(
               ...fileData.invitations.map((inv) => inv.originalUrl || `/in/${inv.profileId}`)
             );
+          } else if (fileData.connections) {
+            for (const conn of fileData.connections) {
+              if (typeof conn === 'string') {
+                allLinks.push(conn);
+              } else if (conn.url || conn.id || conn.profileId) {
+                allLinks.push(conn.url || `/in/${conn.id || conn.profileId}`);
+              }
+            }
           }
         } catch (fileError) {
           logger.warn(`Failed to load file ${fileRef.fileName}:`, (fileError as Error).message);

--- a/puppeteer/src/domains/storage/services/dynamoDBService.js
+++ b/puppeteer/src/domains/storage/services/dynamoDBService.js
@@ -166,6 +166,20 @@ class DynamoDBService {
   }
 
   /**
+   * Replace the full messages list on an edge (used after scraping a conversation).
+   * @param {string} profileId - Connection profile ID
+   * @param {Array} messages - Array of message objects {content, timestamp, sender}
+   * @returns {Promise<Object>} Update result
+   */
+  async updateMessages(profileId, messages) {
+    return await this._post('edges', {
+      operation: 'update_messages',
+      profileId,
+      updates: { messages },
+    });
+  }
+
+  /**
    * Check if an edge relationship exists between user and connection profile
    * The user ID is extracted from the JWT token in the Lambda function
    * @param {string} connectionProfileId - Connection profile ID to check

--- a/tests/backend/unit/test_edge_service.py
+++ b/tests/backend/unit/test_edge_service.py
@@ -541,6 +541,121 @@ class TestEdgeServiceMessageCap:
         assert result['success'] is True
 
 
+class TestEdgeServiceUpdateMessages:
+    """Tests for update_messages operation."""
+
+    def test_update_messages_success(self):
+        """Should replace the full messages list on an edge."""
+        mock_table = MagicMock()
+        service = EdgeService(table=mock_table)
+
+        messages = [
+            {'content': 'Hello', 'timestamp': '2024-01-01T00:00:00', 'type': 'outbound'},
+            {'content': 'Hi there', 'timestamp': '2024-01-01T00:01:00', 'type': 'inbound'},
+        ]
+
+        result = service.update_messages(
+            user_id='test-user',
+            profile_id='john-doe',
+            messages=messages
+        )
+
+        assert result['success'] is True
+        assert result['messageCount'] == 2
+        mock_table.update_item.assert_called_once()
+
+        # Verify the update expression sets messages
+        call_kwargs = mock_table.update_item.call_args[1]
+        assert ':msgs' in call_kwargs['ExpressionAttributeValues']
+        assert len(call_kwargs['ExpressionAttributeValues'][':msgs']) == 2
+
+    def test_update_messages_caps_at_max(self):
+        """Should trim to MAX_MESSAGES_PER_EDGE when list exceeds cap."""
+        mock_table = MagicMock()
+        service = EdgeService(table=mock_table)
+
+        messages = [
+            {'content': f'msg-{i}', 'timestamp': f'2024-01-01T{i:02d}:00:00', 'type': 'outbound'}
+            for i in range(150)
+        ]
+
+        result = service.update_messages(
+            user_id='test-user',
+            profile_id='john-doe',
+            messages=messages
+        )
+
+        assert result['success'] is True
+        assert result['messageCount'] == 100
+
+        call_kwargs = mock_table.update_item.call_args[1]
+        stored_msgs = call_kwargs['ExpressionAttributeValues'][':msgs']
+        assert len(stored_msgs) == 100
+        # Should keep the most recent (last 100)
+        assert stored_msgs[0]['content'] == 'msg-50'
+        assert stored_msgs[-1]['content'] == 'msg-149'
+
+    def test_update_messages_empty_list(self):
+        """Should handle empty messages list."""
+        mock_table = MagicMock()
+        service = EdgeService(table=mock_table)
+
+        result = service.update_messages(
+            user_id='test-user',
+            profile_id='john-doe',
+            messages=[]
+        )
+
+        assert result['success'] is True
+        assert result['messageCount'] == 0
+
+    def test_update_messages_none_list(self):
+        """Should handle None messages."""
+        mock_table = MagicMock()
+        service = EdgeService(table=mock_table)
+
+        result = service.update_messages(
+            user_id='test-user',
+            profile_id='john-doe',
+            messages=None
+        )
+
+        assert result['success'] is True
+        assert result['messageCount'] == 0
+
+    def test_update_messages_dynamo_error(self):
+        """Should raise ExternalServiceError on DynamoDB failure."""
+        mock_table = MagicMock()
+        mock_table.update_item.side_effect = ClientError(
+            {'Error': {'Code': 'InternalServerError', 'Message': 'Test error'}},
+            'UpdateItem'
+        )
+        service = EdgeService(table=mock_table)
+
+        with pytest.raises(ExternalServiceError):
+            service.update_messages(
+                user_id='test-user',
+                profile_id='john-doe',
+                messages=[{'content': 'test', 'timestamp': '2024-01-01', 'type': 'outbound'}]
+            )
+
+    def test_update_messages_encodes_profile_id(self):
+        """Should base64-encode profile ID for DynamoDB key."""
+        mock_table = MagicMock()
+        service = EdgeService(table=mock_table)
+
+        result = service.update_messages(
+            user_id='test-user',
+            profile_id='john-doe',
+            messages=[]
+        )
+
+        call_kwargs = mock_table.update_item.call_args[1]
+        expected_b64 = base64.urlsafe_b64encode('john-doe'.encode()).decode()
+        assert call_kwargs['Key']['SK'] == f'PROFILE#{expected_b64}'
+        assert result['profileId'] == expected_b64
+
+
 class TestEdgeServiceMaxResults:
     """Tests for maxResults cap in search."""
 

--- a/tests/backend/unit/test_edge_service.py
+++ b/tests/backend/unit/test_edge_service.py
@@ -273,7 +273,7 @@ class TestEdgeServiceCheckExists:
 
         result = service.check_exists(
             user_id='test-user',
-            profile_id_b64='dGVzdC1wcm9maWxl'
+            profile_id='test-profile'
         )
 
         assert result['success'] is True
@@ -289,7 +289,7 @@ class TestEdgeServiceCheckExists:
 
         result = service.check_exists(
             user_id='test-user',
-            profile_id_b64='dGVzdC1wcm9maWxl'
+            profile_id='test-profile'
         )
 
         assert result['success'] is True


### PR DESCRIPTION
## Summary
- Add `LinkedInMessageScraperService` to extract conversations from LinkedIn's messaging UI
- Integrate message scraping into profile init pipeline (runs after edge creation, non-blocking)
- Scrape visible conversation thread after sending a message (fire-and-forget)
- Add `update_messages` edge operation to replace full message list on an edge
- Wire up frontend `useMessageHistory` hook to fetch real data from API

## Test plan
- [ ] Verify `npm run lint` passes
- [ ] Verify `npm run test` passes — 12 new scraper tests, 6 new backend tests
- [ ] Manual: run profile init, verify messages appear on connections in DynamoDB
- [ ] Manual: send a message, verify conversation history updates in DynamoDB

> **Note:** Stacked on #backend-pipeline — merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message history now syncs with live conversation data.
  * Messages are automatically captured and stored from conversations.
  * Added message update and persistence capabilities.

* **Bug Fixes**
  * Fixed message history retrieval to use real data instead of placeholder implementation.

* **Tests**
  * Added comprehensive test coverage for message scraping, storage, and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->