### PR TITLE
feat: populate and display profile pictures from LinkedIn CDN

### DIFF
--- a/backend/lambdas/edge-processing/services/edge_service.py
+++ b/backend/lambdas/edge-processing/services/edge_service.py
@@ -470,6 +470,7 @@ class EdgeService(BaseService):
             'last_action_summary': edge_item.get('lastActionSummary', ''),
             'status': edge_item.get('status', ''),
             'conversion_likelihood': conversion_likelihood,
+            'profile_picture_url': profile_data.get('profilePictureUrl', ''),
             'message_history': messages if isinstance(messages, list) else [],
         }
 

--- a/frontend/src/features/connections/components/ConnectionCard.test.tsx
+++ b/frontend/src/features/connections/components/ConnectionCard.test.tsx
@@ -93,4 +93,42 @@ describe('ConnectionCard', () => {
     // Avatar shows first letters of first and last name
     expect(screen.getByText('JD')).toBeInTheDocument();
   });
+
+  it('should render profile picture when profile_picture_url is set', () => {
+    const connectionWithPic = {
+      ...mockConnection,
+      profile_picture_url: 'https://media.licdn.com/dms/image/test/photo.jpg',
+    };
+    const { container } = render(<ConnectionCard connection={connectionWithPic} />);
+
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.src).toBe('https://media.licdn.com/dms/image/test/photo.jpg');
+    expect(img.getAttribute('referrerpolicy')).toBe('no-referrer');
+    // Initials should not be shown
+    expect(screen.queryByText('JD')).not.toBeInTheDocument();
+  });
+
+  it('should render initials when no profile_picture_url', () => {
+    const { container } = render(<ConnectionCard connection={mockConnection} />);
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('should fall back to initials on image error', () => {
+    const connectionWithPic = {
+      ...mockConnection,
+      profile_picture_url: 'https://media.licdn.com/dms/image/test/expired.jpg',
+    };
+    const { container } = render(<ConnectionCard connection={connectionWithPic} />);
+
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    fireEvent.error(img);
+
+    // After error, should show initials instead
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/connections/components/ConnectionCard.tsx
+++ b/frontend/src/features/connections/components/ConnectionCard.tsx
@@ -47,6 +47,11 @@ const ConnectionCard = ({
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const [isTagsOpen, setIsTagsOpen] = useState(false);
   const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [connection.profile_picture_url]);
+
   const isHttpUrl = (value: string): boolean => /^https?:\/\//i.test(value);
 
   const isVanitySlug = (value: string): boolean => /^[a-zA-Z0-9-]+$/.test(value);

--- a/frontend/src/features/connections/components/ConnectionCard.tsx
+++ b/frontend/src/features/connections/components/ConnectionCard.tsx
@@ -46,6 +46,7 @@ const ConnectionCard = ({
 }: ConnectionCardProps) => {
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const [isTagsOpen, setIsTagsOpen] = useState(false);
+  const [imgError, setImgError] = useState(false);
   const isHttpUrl = (value: string): boolean => /^https?:\/\//i.test(value);
 
   const isVanitySlug = (value: string): boolean => /^[a-zA-Z0-9-]+$/.test(value);
@@ -302,9 +303,21 @@ const ConnectionCard = ({
             </div>
           )}
           {/* Profile Picture Space */}
-          <div className="w-12 h-12 bg-gradient-to-r from-blue-500 to-purple-500 rounded-full flex items-center justify-center text-white font-semibold">
-            {connection.first_name[0]}
-            {connection.last_name[0]}
+          <div className="w-12 h-12 rounded-full flex items-center justify-center overflow-hidden flex-shrink-0">
+            {connection.profile_picture_url && !imgError ? (
+              <img
+                src={connection.profile_picture_url}
+                alt=""
+                className="w-full h-full object-cover"
+                onError={() => setImgError(true)}
+                referrerPolicy="no-referrer"
+              />
+            ) : (
+              <div className="w-full h-full bg-gradient-to-r from-blue-500 to-purple-500 flex items-center justify-center text-white font-semibold">
+                {connection.first_name[0]}
+                {connection.last_name[0]}
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -117,6 +117,9 @@ export interface Connection {
   /** Conversion likelihood classification for 'possible' connections (enum string, optional) */
   conversion_likelihood?: ConversionLikelihood;
 
+  /** Profile picture URL from LinkedIn CDN (optional, may expire) */
+  profile_picture_url?: string;
+
   /** Array of message history (optional) */
   message_history?: Message[];
 

--- a/frontend/src/shared/types/validators.ts
+++ b/frontend/src/shared/types/validators.ts
@@ -140,6 +140,7 @@ const connectionSchema = z.object({
     .max(MAX_ARRAY_LENGTH.COMMON_INTERESTS)
     .optional(),
   tags: z.array(z.string().min(1).max(MAX_TEXT_LENGTH.TAG)).max(MAX_ARRAY_LENGTH.TAGS).optional(),
+  profile_picture_url: z.string().url().max(500).optional(),
   message_history: z.array(messageSchema).max(MAX_ARRAY_LENGTH.MESSAGES).optional(),
   isFakeData: z.boolean().optional(),
 });
@@ -253,6 +254,7 @@ export function validateConnection(
         'last_action_summary',
         'date_added',
         'linkedin_url',
+        'profile_picture_url',
       ].includes(path0);
       if (isOptionalField && issue.code === 'too_big') {
         warnings.push(msg);
@@ -423,6 +425,12 @@ export function sanitizeConnectionData(data: unknown): Connection | null {
       connection.date_added = obj.date_added;
     if (typeof obj.linkedin_url === 'string' && isValidUrl(obj.linkedin_url))
       connection.linkedin_url = obj.linkedin_url;
+    if (
+      typeof obj.profile_picture_url === 'string' &&
+      obj.profile_picture_url.length > 0 &&
+      isValidUrl(obj.profile_picture_url)
+    )
+      connection.profile_picture_url = obj.profile_picture_url.substring(0, 500);
     if (typeof obj.isFakeData === 'boolean') connection.isFakeData = obj.isFakeData;
     if (Array.isArray(obj.common_interests)) {
       connection.common_interests = obj.common_interests

--- a/puppeteer/src/domains/profile/services/profileInitService.ts
+++ b/puppeteer/src/domains/profile/services/profileInitService.ts
@@ -614,7 +614,7 @@ export class ProfileInitService {
       // Extract profile picture URLs while still on the connections list page
       let pictureUrls: Record<string, string> = {};
       try {
-        pictureUrls = await this.puppeteerService.extractProfilePictures();
+        pictureUrls = await this.puppeteer.extractProfilePictures();
       } catch (error) {
         logger.warn('Failed to extract profile pictures (non-fatal):', error);
       }

--- a/tests/backend/unit/test_edge_service.py
+++ b/tests/backend/unit/test_edge_service.py
@@ -656,6 +656,65 @@ class TestEdgeServiceUpdateMessages:
         assert result['profileId'] == expected_b64
 
 
+class TestEdgeServiceProfilePicture:
+    """Tests for profile_picture_url in _format_connection_object."""
+
+    def test_format_connection_returns_profile_picture_url(self):
+        """Should return profile_picture_url from profile metadata."""
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            'Items': [
+                {
+                    'PK': 'USER#test-user',
+                    'SK': 'PROFILE#dGVzdC1wcm9maWxl',
+                    'status': 'ally',
+                    'addedAt': '2024-01-01T00:00:00+00:00',
+                    'messages': []
+                }
+            ]
+        }
+        mock_table.get_item.return_value = {
+            'Item': {
+                'name': 'John Doe',
+                'profilePictureUrl': 'https://media.licdn.com/dms/image/test/photo.jpg',
+            }
+        }
+
+        service = EdgeService(table=mock_table)
+        result = service.get_connections_by_status(user_id='test-user', status='ally')
+
+        assert result['success'] is True
+        conn = result['connections'][0]
+        assert conn['profile_picture_url'] == 'https://media.licdn.com/dms/image/test/photo.jpg'
+
+    def test_format_connection_returns_empty_string_when_no_picture(self):
+        """Should return empty string when profilePictureUrl not in metadata."""
+        mock_table = MagicMock()
+        mock_table.query.return_value = {
+            'Items': [
+                {
+                    'PK': 'USER#test-user',
+                    'SK': 'PROFILE#dGVzdC1wcm9maWxl',
+                    'status': 'ally',
+                    'addedAt': '2024-01-01T00:00:00+00:00',
+                    'messages': []
+                }
+            ]
+        }
+        mock_table.get_item.return_value = {
+            'Item': {
+                'name': 'John Doe',
+            }
+        }
+
+        service = EdgeService(table=mock_table)
+        result = service.get_connections_by_status(user_id='test-user', status='ally')
+
+        assert result['success'] is True
+        conn = result['connections'][0]
+        assert conn['profile_picture_url'] == ''
+
+
 class TestEdgeServiceMaxResults:
     """Tests for maxResults cap in search."""
 


### PR DESCRIPTION
Extract profile picture URLs during connection list scraping, pass them through the batch init pipeline to DynamoDB, return them in the edge API response, and render them in ConnectionCard with graceful fallback to gradient initials when URLs expire or fail to load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connections now display profile pictures when available, with automatic fallback to initials if the image is missing or fails to load.

* **Improvements**
  * Improved collection and propagation of profile picture URLs so more connections show images and missing pictures are handled consistently.

* **Tests**
  * Added comprehensive tests covering image rendering, error fallback, and backend handling of profile picture data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->