### PR TITLE
feat: capture profile pictures during search and add mock data

### DIFF
--- a/backend/lambdas/dynamodb-api/lambda_function.py
+++ b/backend/lambdas/dynamodb-api/lambda_function.py
@@ -127,6 +127,11 @@ def lambda_handler(event: dict[str, Any], context) -> dict[str, Any]:
             if 'error' in result:
                 return create_response(400, result)
             return create_response(200, result)
+        elif operation == 'update_profile_picture':
+            result = service.update_profile_picture(user_id, body)
+            if 'error' in result:
+                return create_response(400, result)
+            return create_response(200, result)
         else:
             return create_response(
                 400,
@@ -138,6 +143,7 @@ def lambda_handler(event: dict[str, Any], context) -> dict[str, Any]:
                         'get_user_settings',
                         'update_user_settings',
                         'update_user_profile',
+                        'update_profile_picture',
                     ],
                 },
                 _get_origin_from_event(event),

--- a/backend/lambdas/dynamodb-api/services/dynamodb_api_service.py
+++ b/backend/lambdas/dynamodb-api/services/dynamodb_api_service.py
@@ -204,7 +204,7 @@ class DynamoDBApiService(BaseService):
             return {'error': 'profileId is required'}
 
         picture_url = body.get('profilePictureUrl', '')
-        if picture_url and (not picture_url.startswith('https://') or len(picture_url) > 500):
+        if picture_url and (len(picture_url) > 500 or not self._is_safe_url(picture_url)):
             return {'error': 'Invalid profilePictureUrl'}
 
         profile_id_b64 = base64.urlsafe_b64encode(profile_id.encode()).decode()

--- a/backend/lambdas/dynamodb-api/services/dynamodb_api_service.py
+++ b/backend/lambdas/dynamodb-api/services/dynamodb_api_service.py
@@ -197,6 +197,29 @@ class DynamoDBApiService(BaseService):
             'evaluated': True,
         }
 
+    def update_profile_picture(self, user_id: str, body: dict[str, Any]) -> dict[str, Any]:
+        """Update only the profilePictureUrl field on an existing profile metadata record."""
+        profile_id = body.get('profileId')
+        if not profile_id:
+            return {'error': 'profileId is required'}
+
+        picture_url = body.get('profilePictureUrl', '')
+        if picture_url and (not picture_url.startswith('https://') or len(picture_url) > 500):
+            return {'error': 'Invalid profilePictureUrl'}
+
+        profile_id_b64 = base64.urlsafe_b64encode(profile_id.encode()).decode()
+
+        self.table.update_item(
+            Key={'PK': f'PROFILE#{profile_id_b64}', 'SK': '#METADATA'},
+            UpdateExpression='SET profilePictureUrl = :url, updatedAt = :now',
+            ExpressionAttributeValues={
+                ':url': picture_url,
+                ':now': datetime.now(UTC).isoformat(),
+            },
+        )
+
+        return {'message': 'Profile picture updated', 'profileId': profile_id_b64}
+
     def get_user_settings(self, user_id: str) -> dict[str, Any] | None:
         """Get user settings item (e.g., encrypted linkedin_credentials).
         Key: PK=USER#<sub>, SK=#SETTINGS

--- a/mock-linkedin/data/mock-data.json
+++ b/mock-linkedin/data/mock-data.json
@@ -11,7 +11,8 @@
       "about": "Building serverless AI platforms on AWS.",
       "isConnected": false,
       "connectionDegree": "2nd",
-      "recentActivity": "Liked multiple posts recently"
+      "recentActivity": "Liked multiple posts recently",
+      "profilePictureUrl": "https://media.licdn.com/dms/image/mock/christopher-galliart.jpg"
     },
     {
       "profileId": "john-smith-12345",
@@ -24,7 +25,8 @@
       "about": "Building scalable systems at AWS.",
       "isConnected": true,
       "connectionDegree": "1st",
-      "recentActivity": "Liked a post about cloud architecture"
+      "recentActivity": "Liked a post about cloud architecture",
+      "profilePictureUrl": "https://media.licdn.com/dms/image/mock/john-smith.jpg"
     },
     {
       "profileId": "jane-doe-67890",
@@ -37,7 +39,8 @@
       "about": "Building products that users love at AWS.",
       "isConnected": true,
       "connectionDegree": "1st",
-      "recentActivity": "Shared an article about serverless"
+      "recentActivity": "Shared an article about serverless",
+      "profilePictureUrl": "https://media.licdn.com/dms/image/mock/jane-doe.jpg"
     },
     {
       "profileId": "bob-wilson-11111",
@@ -50,7 +53,8 @@
       "about": "Technology leader focused on AI and machine learning at AWS.",
       "isConnected": true,
       "connectionDegree": "1st",
-      "recentActivity": "Commented on a post about ML pipelines"
+      "recentActivity": "Commented on a post about ML pipelines",
+      "profilePictureUrl": "https://media.licdn.com/dms/image/mock/bob-wilson.jpg"
     },
     {
       "profileId": "alice-johnson-22222",
@@ -63,7 +67,8 @@
       "about": "Turning data into insights. PhD in Statistics.",
       "isConnected": false,
       "connectionDegree": "2nd",
-      "recentActivity": "Liked 3 posts this week"
+      "recentActivity": "Liked 3 posts this week",
+      "profilePictureUrl": "https://media.licdn.com/dms/image/mock/alice-johnson.jpg"
     }
   ],
   "pendingInvitations": [],

--- a/mock-linkedin/server.js
+++ b/mock-linkedin/server.js
@@ -265,7 +265,7 @@ function generatePlaceholderPage(pageName, data = {}) {
             (person) => `
           <li class="reusable-search__result-container">
             <div class="entity-result">
-              ${person.profilePictureUrl ? `<img src="${person.profilePictureUrl}" alt="" style="width:72px;height:72px;border-radius:50%;object-fit:cover;">` : ''}
+              ${person.profilePictureUrl ? `<img src="${escapeHtml(person.profilePictureUrl)}" alt="" style="width:72px;height:72px;border-radius:50%;object-fit:cover;">` : ''}
               <a href="/in/${person.profileId}/" class="entity-result__title-text">
                 <span>${person.name}</span>
               </a>

--- a/mock-linkedin/server.js
+++ b/mock-linkedin/server.js
@@ -265,6 +265,7 @@ function generatePlaceholderPage(pageName, data = {}) {
             (person) => `
           <li class="reusable-search__result-container">
             <div class="entity-result">
+              ${person.profilePictureUrl ? `<img src="${person.profilePictureUrl}" alt="" style="width:72px;height:72px;border-radius:50%;object-fit:cover;">` : ''}
               <a href="/in/${person.profileId}/" class="entity-result__title-text">
                 <span>${person.name}</span>
               </a>
@@ -349,6 +350,7 @@ function generatePlaceholderPage(pageName, data = {}) {
           .map(
             (conn) => `
           <li class="mn-connection-card">
+            ${conn.profilePictureUrl ? `<img src="${escapeHtml(conn.profilePictureUrl)}" alt="" style="width:48px;height:48px;border-radius:50%;object-fit:cover;">` : ''}
             <a href="/in/${conn.profileId}/" data-test-id="connection-card">
               <span class="mn-connection-card__name">${conn.name}</span>
             </a>
@@ -578,7 +580,7 @@ function generateSearchResultsHtml(people) {
       (person) => `
     <li class="reusable-search__result-container" style="padding:12px; margin-bottom:8px; background:white; border-radius:8px; list-style:none;">
       <div class="entity-result" style="display:flex; align-items:flex-start; gap:12px;">
-        <div style="width:72px; height:72px; background:#e7e2dc; border-radius:50%; flex-shrink:0;"></div>
+        ${person.profilePictureUrl ? `<img src="${escapeHtml(person.profilePictureUrl)}" alt="" style="width:72px; height:72px; border-radius:50%; object-fit:cover; flex-shrink:0;">` : `<div style="width:72px; height:72px; background:#e7e2dc; border-radius:50%; flex-shrink:0;"></div>`}
         <div style="flex:1;">
           <a href="https://www.linkedin.com/in/${escapeHtml(person.profileId)}/" class="entity-result__title-text app-aware-link" style="font-weight:600; color:#000; text-decoration:none; display:block; margin-bottom:4px;">
             <span>${escapeHtml(person.name)}</span>
@@ -842,6 +844,15 @@ app.post('/profiles', (req, res) => {
     console.log(`✅ Updated profile "${profileId}":`);
     console.log('   Updates:', JSON.stringify(updates, null, 2));
     return res.json({ success: true, profile: state.profiles[profileId] });
+  }
+
+  if (operation === 'update_profile_picture') {
+    const pictureUrl = req.body.profilePictureUrl || '';
+    state.profiles[profileId] = state.profiles[profileId] || {};
+    state.profiles[profileId].profilePictureUrl = pictureUrl;
+    state.profiles[profileId].updatedAt = new Date().toISOString();
+    console.log(`✅ Updated profile picture for "${profileId}": ${pictureUrl}`);
+    return res.json({ message: 'Profile picture updated', profileId });
   }
 
   console.log('❌ Unknown operation:', operation);

--- a/puppeteer/src/domains/linkedin/services/linkedinService.test.js
+++ b/puppeteer/src/domains/linkedin/services/linkedinService.test.js
@@ -92,6 +92,7 @@ function createMockPuppeteerService() {
     waitForSelector: vi.fn().mockResolvedValue({ click: vi.fn() }),
     waitForFunction: vi.fn().mockResolvedValue(),
     extractLinks: vi.fn().mockResolvedValue([]),
+    extractProfilePictures: vi.fn().mockResolvedValue({}),
     _page: mockInternalPage,
   };
 }
@@ -273,22 +274,22 @@ describe('LinkedInService', () => {
     it('returns extracted links from page', async () => {
       mockPuppeteer.extractLinks.mockResolvedValue(['/in/user1', '/in/user2']);
 
-      const links = await service.getLinksFromPeoplePage(1, '12345');
-      expect(links).toEqual(['/in/user1', '/in/user2']);
+      const result = await service.getLinksFromPeoplePage(1, '12345');
+      expect(result.links).toEqual(['/in/user1', '/in/user2']);
     });
 
-    it('returns empty array on navigation error', async () => {
+    it('returns empty result on navigation error', async () => {
       mockPuppeteer.goto.mockRejectedValue(new Error('Navigation failed'));
 
-      const links = await service.getLinksFromPeoplePage(1, '12345');
-      expect(links).toEqual([]);
+      const result = await service.getLinksFromPeoplePage(1, '12345');
+      expect(result).toEqual({ links: [], pictureUrls: {} });
     });
 
-    it('returns empty array when no content found', async () => {
+    it('returns empty result when no content found', async () => {
       mockPuppeteer.waitForSelector.mockResolvedValue(false);
 
-      const links = await service.getLinksFromPeoplePage(1, '12345');
-      expect(links).toEqual([]);
+      const result = await service.getLinksFromPeoplePage(1, '12345');
+      expect(result).toEqual({ links: [], pictureUrls: {} });
     });
   });
 

--- a/puppeteer/src/domains/storage/services/dynamoDBService.js
+++ b/puppeteer/src/domains/storage/services/dynamoDBService.js
@@ -154,6 +154,20 @@ class DynamoDBService {
   }
 
   /**
+   * Update only the profile picture URL on an existing profile metadata record.
+   * @param {string} profileId - Profile identifier
+   * @param {string} pictureUrl - LinkedIn CDN picture URL
+   * @returns {Promise<Object>} Update result
+   */
+  async updateProfilePictureUrl(profileId, pictureUrl) {
+    return await this._post('dynamodb', {
+      operation: 'update_profile_picture',
+      profileId,
+      profilePictureUrl: pictureUrl,
+    });
+  }
+
+  /**
    * Public: Single entrypoint to upsert edge status (create if missing, update otherwise)
    */
   async upsertEdgeStatus(profileId, status, extraUpdates = {}) {


### PR DESCRIPTION
Extract profile picture URLs from each search results page alongside link collection, accumulate across pages, and update the profile metadata record after RAGStack scrape via a new targeted update_profile_picture Lambda operation that uses update_item to avoid clobbering scraped profile data.

Add profilePictureUrl and img tags to mock LinkedIn data and templates so the full pipeline can be tested end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile picture extraction from LinkedIn profiles.
  * Profile pictures now display in search results and profile listings when available.
  * Ability to update profile picture URLs on existing profiles.
  * Profile picture data is persisted alongside user information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->